### PR TITLE
Fixed docker images publication

### DIFF
--- a/bot/bot.Dockerfile
+++ b/bot/bot.Dockerfile
@@ -9,4 +9,4 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]

--- a/scrapper/scrapper.Dockerfile
+++ b/scrapper/scrapper.Dockerfile
@@ -9,4 +9,4 @@ COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./
 COPY --from=builder application/ ./
 
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
Исправил докер образы, раньше выдавало ошибку: "Could not find or load main class org.springframework.boot.loader.JarLauncher".